### PR TITLE
Update bundle configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,6 +33,7 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
+                        ->performNoDeepMerging()
                         ->beforeNormalization()
                             ->ifTrue(function($v) { return is_scalar($v); })
                             ->then(function($v) { return [$v => []]; })


### PR DESCRIPTION
Hi,

Using "performNoDeepMerging" on `buses` configuration will allow configuration override.

Then we can a production ready configuration in `config.yml` like this:
```
rezzza_command_bus:
    buses:
        synchronous: direct
        asynchronous:
            rabbitmq:
                producer_guesser: rezzza_command_bus.old_sound_rabbit.producer_guesser
                consumer_bus: synchronous
```

And have a different configuration in our `config_test.yml` (that override some part only):
```
rezzza_command_bus:
    buses:
        asynchronous:
            service:
                id: rezzza_command_bus.my_command_bus.mocked_bus
```

Using this settings and a `performNoDeepMerging`, we can simply mock our bus \o/ or update configuration for some specific cases. 
Else (actually) we will have a "You can't have more than bus provider defined." message.

I don't see any possible BCBreak here.